### PR TITLE
Fix iOS resume print page breaks

### DIFF
--- a/app/components/home/welcome.tsx
+++ b/app/components/home/welcome.tsx
@@ -23,7 +23,6 @@ const Welcome = () => {
             <a
               className="btn"
               href="/resume"
-              rel="noreferrer"
             >
               Résumé
             </a>

--- a/app/resume/footer-subsection.tsx
+++ b/app/resume/footer-subsection.tsx
@@ -20,7 +20,7 @@ const FooterSubsection: React.FC<{
     dates: string;
     responsibilities: string[];
   }>;
-  icons?: Array<{ src: string; height: number; width: number }>;
+  icons?: Array<{ src: string; height: number; width: number; label: string }>;
   otherExperience?: string;
 }> = ({ icon, children, isCollapsed, onToggle, data, icons, otherExperience }) => {
   return (
@@ -64,12 +64,13 @@ const FooterSubsection: React.FC<{
                 <div className="icon-container" key={index}>
                   <Image
                     key={index}
-                    className="icon-container"
+                    className="skill-icon"
                     src={icon.src}
                     height={icon.height}
                     width={icon.width}
-                    alt={`icon-${index}`}
+                    alt={icon.label}
                   />
+                  <span className="icon-label">{icon.label}</span>
                 </div>
               );
             })}

--- a/app/resume/footer-subsection.tsx
+++ b/app/resume/footer-subsection.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import ExperienceItem from "./experience-item";
 import Image from "next/image";
+import { StaticImageData } from "next/image";
 
 const FooterSubsection: React.FC<{
   icon: IconDefinition;
@@ -20,7 +21,7 @@ const FooterSubsection: React.FC<{
     dates: string;
     responsibilities: string[];
   }>;
-  icons?: Array<{ src: string; height: number; width: number; label: string }>;
+  icons?: Array<{ src: StaticImageData; label: string }>;
   otherExperience?: string;
 }> = ({ icon, children, isCollapsed, onToggle, data, icons, otherExperience }) => {
   return (

--- a/app/resume/footer-subsection.tsx
+++ b/app/resume/footer-subsection.tsx
@@ -67,8 +67,8 @@ const FooterSubsection: React.FC<{
                     key={index}
                     className="skill-icon"
                     src={icon.src}
-                    height={icon.height}
-                    width={icon.width}
+                    height={icon.src.height}
+                    width={icon.src.width}
                     alt={icon.label}
                   />
                   <span className="icon-label">{icon.label}</span>

--- a/app/resume/footer-subsection.tsx
+++ b/app/resume/footer-subsection.tsx
@@ -4,7 +4,6 @@ import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import ExperienceItem from "./experience-item";
-import Image from "next/image";
 import { StaticImageData } from "next/image";
 
 const FooterSubsection: React.FC<{
@@ -63,12 +62,9 @@ const FooterSubsection: React.FC<{
             {icons?.map((icon, index) => {
               return (
                 <div className="icon-container" key={index}>
-                  <Image
-                    key={index}
+                  <img
                     className="skill-icon"
-                    src={icon.src}
-                    height={icon.src.height}
-                    width={icon.src.width}
+                    src={icon.src.src}
                     alt={icon.label}
                   />
                   <span className="icon-label">{icon.label}</span>

--- a/app/resume/resume.css
+++ b/app/resume/resume.css
@@ -709,8 +709,7 @@
 
   .subheader-links,
   .work-experience-list,
-  .subsection-body,
-  .footer-section {
+  .subsection-body {
     max-height: none !important;
     overflow: visible !important;
     transition: none !important;
@@ -722,28 +721,28 @@
     max-height: none !important;
   }
 
-  .resume-body,
-  .work-experience-list,
-  .footer-section,
-  .footer-sub-section,
-  .subsection-body,
-  .body-section,
-  .body-section-slim {
-    display: block !important;
+  .work-experience-list {
+    display: flex !important;
+    flex-wrap: wrap !important;
+    justify-content: space-between !important;
+  }
+
+  .body-section {
     width: 100% !important;
   }
 
-  .work-experience-list,
-  .footer-section {
-    padding-left: 0;
-    padding-right: 0;
-    gap: 0;
+  .body-section-slim {
+    width: 31% !important;
   }
 
-  .body-section,
-  .body-section-slim,
+  .footer-section {
+    display: grid !important;
+    grid-template-columns: 2fr 1fr !important;
+    grid-gap: 20px !important;
+    row-gap: 0 !important;
+  }
+
   .footer-sub-section {
-    margin-bottom: 18px;
     break-inside: avoid;
     page-break-inside: avoid;
     -webkit-column-break-inside: avoid;
@@ -868,6 +867,8 @@
     height: 34px;
     object-fit: contain;
     display: block;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 
   .icon-label {
@@ -889,16 +890,22 @@
   }
 
   .footer-section .footer-sub-section {
-    border-right: none;
-    border-bottom: 1px solid #171717;
-    padding: 0 0 12px;
+    padding-top: 10px;
+    padding-bottom: 0;
     padding-left: 0 !important;
-    padding-right: 0 !important;
+    padding-right: 25px;
+    border-right: 1px solid #171717;
+    border-bottom: none;
   }
 
-  .footer-section .footer-sub-section:last-of-type {
-    border-bottom: none;
-    padding-bottom: 0;
+  .footer-section .footer-sub-section:first-of-type,
+  .footer-section .footer-sub-section:nth-of-type(3) {
+    padding-left: 0 !important;
+  }
+
+  .footer-section .footer-sub-section:last-of-type,
+  .footer-section .footer-sub-section:nth-of-type(2) {
+    border-right: none;
   }
 
   .footer-section{

--- a/app/resume/resume.css
+++ b/app/resume/resume.css
@@ -302,13 +302,15 @@
 }
 
 .icon-grid {
-  margin: 20px 0;
+  margin: 16px 0;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 20px;
+  gap: 16px;
 
   .icon-container {
     display: flex;
+    flex-direction: column;
+    align-items: center;
     justify-content: center;
   }
 
@@ -318,8 +320,15 @@
   }
 }
 
+.icon-label {
+  margin-top: 6px;
+  font-size: 12px;
+  line-height: 1.2;
+  text-align: center;
+}
+
 .other-experience {
-  line-height: 2;
+  line-height: 1.7;
 }
 
 @media screen and (max-width: 768px) {
@@ -657,7 +666,7 @@
     max-width: 1200px; /* Simulate the largest breakpoint width */
     height: auto;
     margin: 0 auto; /* Center the content */
-    padding: 20px; /* Add some padding for print aesthetics */
+    padding: 14px; /* Add some padding for print aesthetics */
     background-color: white;
     box-shadow: none;
     display: block;
@@ -748,7 +757,7 @@
     flex-wrap: nowrap;
     flex-direction: row;
     justify-content: space-between;
-    padding: 20px;
+    padding: 14px;
     border-bottom: 1px solid #171717;
   }
 
@@ -770,7 +779,7 @@
   }
   .resume-header-left h1 {
     font-weight: bold;
-    font-size: 46px;
+    font-size: 42px;
     margin: 0;
     text-align: left;
   }
@@ -784,18 +793,20 @@
     font-family: "Montserrat", sans-serif;
     font-weight: bold;
     text-transform: uppercase;
-    letter-spacing: 5px;
+    letter-spacing: 4px;
     margin: 0;
+    font-size: 24px;
   }
 
   .resume-header-right h3 {
     font-weight: 400;
     font-family: "Satisfy", cursive;
-    font-size: 20px;
+    font-size: 18px;
+    margin: 6px 0 0;
   }
 
   .subheader-links {
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 700;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -811,8 +822,61 @@
     page-break-after: auto;
   }
 
+  .body-header {
+    font-size: 28px;
+    margin-top: 18px;
+    margin-bottom: 8px;
+  }
+
   .work-experience-list {
     border-bottom: unset;
+    padding-top: 12px;
+    gap: 10px;
+  }
+
+  .company-name {
+    font-size: 15px;
+  }
+
+  .job-responsibilities {
+    margin: 0;
+    padding: 6px 0 0 18px;
+  }
+
+  .job-responsibilities li {
+    margin-bottom: 3px;
+    line-height: 1.3;
+  }
+
+  .subsection-title {
+    font-size: 20px;
+    letter-spacing: 2px;
+  }
+
+  .icon-grid {
+    margin: 12px 0;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 10px;
+  }
+
+  .icon-grid .icon-container {
+    gap: 2px;
+  }
+
+  .icon-grid .skill-icon {
+    width: 28px;
+    height: 28px;
+    object-fit: contain;
+  }
+
+  .icon-label {
+    font-size: 9px;
+    line-height: 1.1;
+  }
+
+  .other-experience {
+    font-size: 12px;
+    line-height: 1.4;
   }
 
   .body-header,
@@ -826,7 +890,7 @@
   .footer-section .footer-sub-section {
     border-right: none;
     border-bottom: 1px solid #171717;
-    padding: 0 0 18px;
+    padding: 0 0 10px;
   }
 
   .footer-section .footer-sub-section:last-of-type {
@@ -836,6 +900,6 @@
 
   .footer-section{
     border-top: 1px solid #171717;
-    padding-top: 20px;
+    padding-top: 12px;
   }
 }

--- a/app/resume/resume.css
+++ b/app/resume/resume.css
@@ -672,6 +672,11 @@
     page-break-after: auto;
   }
 
+  .contact-header,
+  .toggle-button {
+    display: none !important;
+  }
+
   .print-button {
     display: none; /* Hide the print button during printing */
   }
@@ -691,6 +696,20 @@
       11in * 2 - 40px
     ); /* Constrain content to two pages minus padding */
     overflow: hidden; /* Hide any overflow */
+  }
+
+  .subheader-links,
+  .work-experience-list,
+  .subsection-body {
+    max-height: none !important;
+    overflow: visible !important;
+    transition: none !important;
+  }
+
+  .subheader-links.collapsed,
+  .work-experience-list.collapsed,
+  .subsection-body.collapsed {
+    max-height: none !important;
   }
 
   /* full styles  */
@@ -760,11 +779,23 @@
 
   .resume-body {
     border-top: 1px solid #171717;
-    break-after: page;
+    break-after: auto;
+    page-break-after: auto;
   }
 
   .work-experience-list {
     border-bottom: unset;
+  }
+
+  .body-header,
+  .body-section,
+  .body-section-slim,
+  .footer-sub-section,
+  .subsection-body,
+  .section-header,
+  .job-responsibilities {
+    break-inside: auto;
+    page-break-inside: auto;
   }
 
   .footer-section{

--- a/app/resume/resume.css
+++ b/app/resume/resume.css
@@ -666,7 +666,7 @@
     max-width: 1200px; /* Simulate the largest breakpoint width */
     height: auto;
     margin: 0 auto; /* Center the content */
-    padding: 14px; /* Add some padding for print aesthetics */
+    padding: 18px; /* Add some padding for print aesthetics */
     background-color: white;
     box-shadow: none;
     display: block;
@@ -757,7 +757,7 @@
     flex-wrap: nowrap;
     flex-direction: row;
     justify-content: space-between;
-    padding: 14px;
+    padding: 18px;
     border-bottom: 1px solid #171717;
   }
 
@@ -779,7 +779,7 @@
   }
   .resume-header-left h1 {
     font-weight: bold;
-    font-size: 42px;
+    font-size: 44px;
     margin: 0;
     text-align: left;
   }
@@ -795,13 +795,13 @@
     text-transform: uppercase;
     letter-spacing: 4px;
     margin: 0;
-    font-size: 24px;
+    font-size: 25px;
   }
 
   .resume-header-right h3 {
     font-weight: 400;
     font-family: "Satisfy", cursive;
-    font-size: 18px;
+    font-size: 19px;
     margin: 6px 0 0;
   }
 
@@ -823,14 +823,14 @@
   }
 
   .body-header {
-    font-size: 28px;
+    font-size: 30px;
     margin-top: 18px;
-    margin-bottom: 8px;
+    margin-bottom: 10px;
   }
 
   .work-experience-list {
     border-bottom: unset;
-    padding-top: 12px;
+    padding-top: 14px;
     gap: 10px;
   }
 
@@ -849,14 +849,14 @@
   }
 
   .subsection-title {
-    font-size: 20px;
+    font-size: 22px;
     letter-spacing: 2px;
   }
 
   .icon-grid {
-    margin: 12px 0;
-    grid-template-columns: repeat(6, 1fr);
-    gap: 10px;
+    margin: 14px 0;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
   }
 
   .icon-grid .icon-container {
@@ -864,19 +864,20 @@
   }
 
   .icon-grid .skill-icon {
-    width: 28px;
-    height: 28px;
+    width: 34px;
+    height: 34px;
     object-fit: contain;
+    display: block;
   }
 
   .icon-label {
-    font-size: 9px;
+    font-size: 10px;
     line-height: 1.1;
   }
 
   .other-experience {
     font-size: 12px;
-    line-height: 1.4;
+    line-height: 1.5;
   }
 
   .body-header,
@@ -890,7 +891,9 @@
   .footer-section .footer-sub-section {
     border-right: none;
     border-bottom: 1px solid #171717;
-    padding: 0 0 10px;
+    padding: 0 0 12px;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
   }
 
   .footer-section .footer-sub-section:last-of-type {
@@ -900,6 +903,6 @@
 
   .footer-section{
     border-top: 1px solid #171717;
-    padding-top: 12px;
+    padding-top: 14px;
   }
 }

--- a/app/resume/resume.css
+++ b/app/resume/resume.css
@@ -909,6 +909,8 @@
   }
 
   .footer-section{
+    break-before: page;
+    page-break-before: always;
     border-top: 1px solid #171717;
     padding-top: 14px;
   }

--- a/app/resume/resume.css
+++ b/app/resume/resume.css
@@ -700,7 +700,8 @@
 
   .subheader-links,
   .work-experience-list,
-  .subsection-body {
+  .subsection-body,
+  .footer-section {
     max-height: none !important;
     overflow: visible !important;
     transition: none !important;
@@ -710,6 +711,33 @@
   .work-experience-list.collapsed,
   .subsection-body.collapsed {
     max-height: none !important;
+  }
+
+  .resume-body,
+  .work-experience-list,
+  .footer-section,
+  .footer-sub-section,
+  .subsection-body,
+  .body-section,
+  .body-section-slim {
+    display: block !important;
+    width: 100% !important;
+  }
+
+  .work-experience-list,
+  .footer-section {
+    padding-left: 0;
+    padding-right: 0;
+    gap: 0;
+  }
+
+  .body-section,
+  .body-section-slim,
+  .footer-sub-section {
+    margin-bottom: 18px;
+    break-inside: avoid;
+    page-break-inside: avoid;
+    -webkit-column-break-inside: avoid;
   }
 
   /* full styles  */
@@ -788,14 +816,22 @@
   }
 
   .body-header,
-  .body-section,
-  .body-section-slim,
-  .footer-sub-section,
   .subsection-body,
   .section-header,
   .job-responsibilities {
     break-inside: auto;
     page-break-inside: auto;
+  }
+
+  .footer-section .footer-sub-section {
+    border-right: none;
+    border-bottom: 1px solid #171717;
+    padding: 0 0 18px;
+  }
+
+  .footer-section .footer-sub-section:last-of-type {
+    border-bottom: none;
+    padding-bottom: 0;
   }
 
   .footer-section{

--- a/app/util/const.ts
+++ b/app/util/const.ts
@@ -177,18 +177,18 @@ export const otherWork = [
 ];
 
 export const icons = [
-  Express,
-  MongoDB,
-  MUI,
-  Next,
-  Node,
-  Postgres,
-  Rails,
-  React,
-  Redux,
-  StyledComponents,
-  TypeScript,
-  xState,
+  { src: Express, label: "Express" },
+  { src: MongoDB, label: "MongoDB" },
+  { src: MUI, label: "MUI" },
+  { src: Next, label: "Next.js" },
+  { src: Node, label: "Node.js" },
+  { src: Postgres, label: "Postgres" },
+  { src: Rails, label: "Rails" },
+  { src: React, label: "React" },
+  { src: Redux, label: "Redux" },
+  { src: StyledComponents, label: "Styled Components" },
+  { src: TypeScript, label: "TypeScript" },
+  { src: xState, label: "XState" },
 ];
 
 export const otherExperience =


### PR DESCRIPTION
## Summary
- remove the forced page break after Work Experience in resume print styles
- disable collapsed-section height and overflow constraints during print
- hide mobile toggle controls in print so Safari gets a plain flowing layout

## Validation
- checked app/resume/resume.css for errors

## Notes
- leaves the unrelated welcome card change out of this PR so the preview stays scoped