### PR TITLE
Rename ToneSmith portfolio card to ToneGrid

### DIFF
--- a/app/util/const.ts
+++ b/app/util/const.ts
@@ -262,7 +262,7 @@ export const portfolioItems = [
   {
     section: "personal" as const,
     image: tonesmith,
-    title: "ToneSmith",
+    title: "ToneGrid",
     subtitle: "Interactive web app",
     date: "March 2026",
     description:


### PR DESCRIPTION
## Summary
- rename the ToneSmith portfolio item to ToneGrid in the shared portfolio data

## Validation
- checked app/util/const.ts for errors

## Notes
- this was committed after PR #34 merged, so it needed a separate follow-up PR