### PR TITLE
Add two issue drafts: Professional animation & Recent Work images

### DIFF
--- a/github-issues/12-replace-professional-section-skill-level-animation-with-more-impressive-experience.md
+++ b/github-issues/12-replace-professional-section-skill-level-animation-with-more-impressive-experience.md
@@ -1,0 +1,20 @@
+Title: Replace Professional section skill level animation with something actually impressive
+
+## Problem
+The current Professional section skill-level animation feels generic and low-signal. It does not communicate senior-level technical depth or create a memorable interaction.
+
+## Goal
+Design and implement a more compelling Professional section animation that feels polished, modern, and aligned with a senior engineer portfolio.
+
+## Scope
+- Replace the existing skill-level animation interaction in the Professional section
+- Preserve existing content hierarchy and accessibility standards
+- Ensure animation performance is smooth on desktop and mobile
+- Keep implementation maintainable within current stack and style architecture
+
+## Acceptance Criteria
+- Professional section no longer uses the current skill-level animation
+- New animation is visually stronger and clearly more deliberate than progress-bar style behavior
+- Animation runs smoothly without noticeable jank on modern browsers
+- Interaction remains accessible (keyboard/focus-safe, does not block content readability, respects reduced-motion preferences)
+- No regressions to surrounding homepage layout or navigation

--- a/github-issues/13-replace-recent-work-images-with-portfolio-page-images.md
+++ b/github-issues/13-replace-recent-work-images-with-portfolio-page-images.md
@@ -1,0 +1,19 @@
+Title: Replace Recent Work images with the images from portfolio page
+
+## Problem
+The homepage Recent Work section uses images that are inconsistent with the portfolio page, creating visual mismatch and duplicated curation effort.
+
+## Goal
+Update Recent Work cards to use the same image assets shown on the portfolio page for the corresponding projects.
+
+## Scope
+- Identify image mapping between Recent Work entries and portfolio page entries
+- Swap Recent Work image sources to portfolio page assets
+- Keep existing card structure, links, and copy unchanged unless required for asset alignment
+- Verify responsive behavior after image swaps
+
+## Acceptance Criteria
+- All Recent Work project cards use the portfolio page images for matching projects
+- Card layout remains stable across mobile and desktop breakpoints
+- No broken image references or missing assets
+- No regressions to portfolio page visuals or routing


### PR DESCRIPTION
### Motivation
- Add explicit board tickets to replace the current Professional section skill-level animation with a higher-impact, accessible interaction and to align homepage Recent Work images with the portfolio page assets.

### Description
- Added `github-issues/12-replace-professional-section-skill-level-animation-with-more-impressive-experience.md` containing Problem/Goal/Scope/Acceptance Criteria for a redesigned Professional animation.
- Added `github-issues/13-replace-recent-work-images-with-portfolio-page-images.md` containing Problem/Goal/Scope/Acceptance Criteria to swap Recent Work images to portfolio assets and verify responsive behavior.

### Testing
- Verified repository state with `git status --short` which listed the two new files as untracked and then committed the changes with `git commit -m "Add two new board tickets for animation and image updates"` which succeeded.
- Inspected the created files with `nl -ba github-issues/12-replace-professional-section-skill-level-animation-with-more-impressive-experience.md` and `nl -ba github-issues/13-replace-recent-work-images-with-portfolio-page-images.md` to confirm contents and formatting for `scripts/create-issues.sh` compatibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d49a87f3cc832e80e413593efe57a4)