### PR TITLE
Remove Bootstrap dependency and add lightweight local CSS primitives

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,10 +30,6 @@ export default function RootLayout({
         <link rel="icon" type="image/png" sizes="32x32" href="/Favicon3.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/Favicon3.png" />
         <link rel="apple-touch-icon" href="/Favicon3.png" />
-        <link
-          rel="stylesheet"
-          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
-        />
       </head>
       <body>
         <GlobalNav />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,6 +30,10 @@ export default function RootLayout({
         <link rel="icon" type="image/png" sizes="32x32" href="/Favicon3.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/Favicon3.png" />
         <link rel="apple-touch-icon" href="/Favicon3.png" />
+      </head>
+      <body>
+        <GlobalNav />
+        {children}
         <GlobalFooter />
         <BuildInfoLogger />
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,10 +30,6 @@ export default function RootLayout({
         <link rel="icon" type="image/png" sizes="32x32" href="/Favicon3.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/Favicon3.png" />
         <link rel="apple-touch-icon" href="/Favicon3.png" />
-      </head>
-      <body>
-        <GlobalNav />
-        {children}
         <GlobalFooter />
         <BuildInfoLogger />
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,9 +10,9 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
-}: Readonly<{
+}: {
   children: React.ReactNode;
-}>) {
+}) {
   const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA ?? "unknown";
   const buildTime = process.env.NEXT_PUBLIC_BUILD_TIME ?? "unknown";
 

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -8,7 +8,7 @@ const professionalItems = portfolioItems.filter((item) => item.section === "prof
 
 const Portfolio = () => {
   return (
-    <div data-spy="scroll" data-target="#navbar-example">
+    <div>
       <div className="jumbotron" id="portfolio">
         <div className="main2">
           <div className="portfolio-container">

--- a/app/styles.css
+++ b/app/styles.css
@@ -1226,7 +1226,7 @@ a {
   min-height: 0;
   width: 50%;
   font-size: 16px;
-  margin: -370px 25% 0;
+  margin: -330px 25% 0;
 }
 
 .welcome .container {

--- a/app/styles.css
+++ b/app/styles.css
@@ -136,6 +136,258 @@ table {
  */
 
 
+/* Bootstrap v3 compatibility layer (local, minimal subset used by this app) */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.42857143;
+  color: #333;
+  background-color: #fff;
+}
+
+a {
+  color: #337ab7;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: #23527c;
+  text-decoration: underline;
+}
+
+p {
+  margin: 0 0 10px;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: inherit;
+  font-weight: 500;
+  line-height: 1.1;
+  color: inherit;
+}
+
+h1,
+h2,
+h3 {
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
+h4,
+h5,
+h6 {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+h1 {
+  font-size: 36px;
+}
+
+h2 {
+  font-size: 30px;
+}
+
+h3 {
+  font-size: 24px;
+}
+
+h4 {
+  font-size: 18px;
+}
+
+h5 {
+  font-size: 14px;
+}
+
+h6 {
+  font-size: 12px;
+}
+
+img {
+  vertical-align: middle;
+  border: 0;
+}
+
+.container {
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+@media (min-width: 768px) {
+  .container {
+    width: 750px;
+  }
+}
+
+@media (min-width: 992px) {
+  .container {
+    width: 970px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .container {
+    width: 1170px;
+  }
+}
+
+.row {
+  margin-right: -15px;
+  margin-left: -15px;
+}
+
+.row::before,
+.row::after {
+  display: table;
+  content: " ";
+}
+
+.row::after {
+  clear: both;
+}
+
+.col-md-1,
+.col-md-4,
+.col-md-5,
+.col-md-6 {
+  position: relative;
+  min-height: 1px;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+@media (min-width: 992px) {
+  .col-md-1,
+  .col-md-4,
+  .col-md-5,
+  .col-md-6 {
+    float: left;
+  }
+
+  .col-md-1 {
+    width: 8.33333333%;
+  }
+
+  .col-md-4 {
+    width: 33.33333333%;
+  }
+
+  .col-md-5 {
+    width: 41.66666667%;
+  }
+
+  .col-md-6 {
+    width: 50%;
+  }
+}
+
+.btn {
+  display: inline-block;
+  padding: 6px 12px;
+  margin-bottom: 0;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.42857143;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  touch-action: manipulation;
+  cursor: pointer;
+  user-select: none;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+
+.btn:focus,
+.btn:active:focus,
+.btn.active:focus,
+.btn.focus,
+.btn:active.focus,
+.btn.active.focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+
+.form-control {
+  display: block;
+  width: 100%;
+  height: 34px;
+  padding: 6px 12px;
+  font-size: 14px;
+  line-height: 1.42857143;
+  color: #555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+}
+
+.form-control:focus {
+  border-color: #66afe9;
+  outline: 0;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
+    0 0 8px rgba(102, 175, 233, 0.6);
+}
+
+label {
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 5px;
+  font-weight: 700;
+}
+
+.jumbotron {
+  padding-top: 30px;
+  padding-bottom: 30px;
+  margin-bottom: 30px;
+  color: inherit;
+  background-color: #eee;
+}
+
+.jumbotron .h1,
+.jumbotron h1 {
+  color: inherit;
+}
+
+.jumbotron p {
+  margin-bottom: 15px;
+  font-size: 21px;
+  font-weight: 200;
+}
+
+@media screen and (min-width: 768px) {
+  .jumbotron {
+    padding-top: 48px;
+    padding-bottom: 48px;
+  }
+
+  .container .jumbotron,
+  .container-fluid .jumbotron {
+    padding-right: 60px;
+    padding-left: 60px;
+  }
+}
+
+
+
 /* Lightweight layout primitives replacing removed Bootstrap dependency */
 *,
 *::before,

--- a/app/styles.css
+++ b/app/styles.css
@@ -135,6 +135,92 @@ table {
     END RESET
  */
 
+
+/* Lightweight layout primitives replacing removed Bootstrap dependency */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+.container {
+  width: 100%;
+  max-width: 1170px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+.row {
+  margin-left: -15px;
+  margin-right: -15px;
+}
+
+.row::before,
+.row::after {
+  content: "";
+  display: table;
+}
+
+.row::after {
+  clear: both;
+}
+
+[class*="col-md-"] {
+  position: relative;
+  min-height: 1px;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+@media (min-width: 992px) {
+  [class*="col-md-"] {
+    float: left;
+  }
+
+  .col-md-1 {
+    width: 8.33333333%;
+  }
+
+  .col-md-4 {
+    width: 33.33333333%;
+  }
+
+  .col-md-5 {
+    width: 41.66666667%;
+  }
+
+  .col-md-6 {
+    width: 50%;
+  }
+}
+
+.btn {
+  display: inline-block;
+  margin-bottom: 0;
+  font-weight: 400;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  border: 1px solid transparent;
+  background-image: none;
+  user-select: none;
+}
+
+.form-control {
+  display: block;
+  width: 100%;
+  line-height: 1.42857143;
+  color: #555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 6px 12px;
+}
+
+
 /* CSS Custom Properties for consistency */
 :root {
   --primary-color: #21d44f;
@@ -1544,7 +1630,6 @@ a {
 
 .form-control {
   margin-bottom: 15px;
-  display: inline-block;
   width: 90%;
 }
 


### PR DESCRIPTION
### Motivation
- Remove the external Bootstrap dependency so the app no longer relies on the Bootstrap CDN for styling.
- Preserve the site’s existing layout and spacing by providing local equivalents for commonly used Bootstrap utilities.

### Description
- Removed the Bootstrap 3 CDN stylesheet link from `app/layout.tsx` so the layout doesn't load external Bootstrap CSS.
- Added lightweight, local CSS primitives to `app/styles.css` including `* { box-sizing }`, `.container`, `.row`, responsive `.col-md-*` widths, `.btn`, and `.form-control` to mimic the existing Bootstrap layout behavior.
- Removed Bootstrap-specific attributes `data-spy` and `data-target` from the portfolio wrapper in `app/portfolio/page.tsx` because those attributes are not functional without Bootstrap JS/CSS.
- Adjusted the existing `.form-control` override so it composes with the new base form control rules and maintains the intended input sizing.

### Testing
- Ran `npm run lint` and received no ESLint warnings or errors, which completed successfully.
- Ran `npm run build` and produced a successful production build with static pages generated, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e546e4a438832eac91940743239eba)